### PR TITLE
Unable to cancel subscription

### DIFF
--- a/subscriber.go
+++ b/subscriber.go
@@ -143,7 +143,7 @@ func (s Subscriber) processEvents(
 			}
 			s.processEvent(d, dataType, eventChan)
 		case <-ctx.Done():
-			if s.opts.processAll && processedAll {
+			if (s.opts.processAll && processedAll) || !s.opts.processAll {
 				close(eventChan)
 				return
 			}


### PR DESCRIPTION
Context.Done() is not being obeyed when processAll = false

Given the following example, the subscriber will not break out of the processEvent loop if either the `timeout` is passed or `cancelFunc()` is called

```go
ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
events := subscriber.SubscribeToExchange(ctx, string(eventType), Event{}, amqp.Consumer{})
for e := range events {
	eventData := e.Data.(*Event)
	if filter == nil || filter(eventData) {
		e.Done()
		return eventData, nil
	}
	e.Done()
}
```

